### PR TITLE
Add pagination for catalog

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "@hookform/resolvers": "^3.3.2",
     "axios": "^1.6.3",
     "firebase": "^10.7.0",
+    "framer-motion": "^10.16.9",
     "lint-staged": "^14.0.1",
     "react": "^18.2.0",
     "react-cookie": "^6.1.1",

--- a/package.json
+++ b/package.json
@@ -12,22 +12,22 @@
     "prepare": "husky install"
   },
   "dependencies": {
+    "@ajna/pagination": "^1.4.19",
     "@chakra-ui/react": "^2.8.2",
     "@emotion/react": "^11.11.1",
     "@emotion/styled": "^11.11.0",
     "@hookform/resolvers": "^3.3.2",
-    "framer-motion": "^10.16.9",
-    "yup": "^1.3.2",
     "axios": "^1.6.3",
     "firebase": "^10.7.0",
     "lint-staged": "^14.0.1",
     "react": "^18.2.0",
-    "react-hook-form": "^7.45.4",
-    "react-html-email": "^3.0.0",
     "react-cookie": "^6.1.1",
     "react-dom": "^18.2.0",
+    "react-hook-form": "^7.45.4",
+    "react-html-email": "^3.0.0",
     "react-router-dom": "^6.20.0",
-    "react-script": "^2.0.5"
+    "react-script": "^2.0.5",
+    "yup": "^1.3.2"
   },
   "lint-staged": {
     "*.{js,jsx}": "yarn run eslint"

--- a/src/components/PaginationFooter/PaginationFooter.jsx
+++ b/src/components/PaginationFooter/PaginationFooter.jsx
@@ -1,0 +1,107 @@
+import { Select, Flex, Box, HStack, Text } from '@chakra-ui/react';
+import {
+    Pagination,
+    usePagination,
+    PaginationNext,
+    PaginationPrevious,
+    PaginationContainer,
+  } from '@ajna/pagination';
+import { useState, useEffect } from 'react';
+import { PropTypes } from 'prop-types';
+import { NPOBackend } from '../../utils/auth_utils';
+
+const PaginationFooter = ({ setData, table }) => {
+    const [rowsPerPage, setRowsPerPage] = useState(10);
+    const [rowRangeString, setRowRangeString] = useState('');
+    const [dataCount, setDataCount] = useState(0);
+  
+    const { currentPage, setCurrentPage, pagesCount } = usePagination({
+      pagesCount: Math.ceil(dataCount / rowsPerPage),
+      initialState: { currentPage: 1 },
+    });
+  
+    // when the number of rows or the next page is clicked, get the desired data from the backend
+    useEffect(() => {
+      const refreshData = async () => {
+        const { data } = await NPOBackend.get(
+          `/${table}?limit=${rowsPerPage}&page=${currentPage}`,
+        );
+        const { count, events: tableData } = data;
+
+        setData(tableData); // data on the page
+        setDataCount(count[0].count); // total number of data across all pages
+
+        const start = (currentPage - 1) * rowsPerPage + 1;
+        setRowRangeString(`${start} - ${start + tableData.length - 1}`); // range of data on the page
+      };
+      refreshData();
+    }, [currentPage, rowsPerPage, setData, table]);
+  
+    useEffect(() => {
+      setCurrentPage(1);
+    }, [setCurrentPage, rowsPerPage, table]);
+
+
+    return (
+      <Flex
+      direction="row"
+      justify="space-between"
+      border="solid"
+      borderWidth="1px"
+      borderColor="#E2E8F0"
+      mx={5}
+      p={3}
+    >
+      <HStack width="17%" spacing={0}>
+        <Box fontSize="14px" width="100%" whitespace="nowrap">
+          Show rows per page&nbsp;
+        </Box>
+        <Select
+          onChange={e => setRowsPerPage(e.target.value)}
+          defaultValue={10}
+          size="sm"
+          width="50%"
+        >
+          <option value="10">10</option>
+          <option value="25">25</option>
+          <option value="50">50</option>
+        </Select>
+      </HStack>
+      <Flex align="center" gap={5}>
+        <Text fontSize="14px">
+          <Text as="b" fontSize="14px">
+            {rowRangeString}
+          </Text>
+          &nbsp;of {dataCount}
+        </Text>
+        <Pagination pagesCount={pagesCount} currentPage={currentPage} onPageChange={setCurrentPage}>
+          <PaginationContainer justify="right">
+            <PaginationPrevious variant="ghost">&lsaquo;</PaginationPrevious>
+            <PaginationNext variant="ghost">&rsaquo;</PaginationNext>
+          </PaginationContainer>
+        </Pagination>
+      </Flex>
+    </Flex>
+      
+    );
+  }
+  PaginationFooter.propTypes = {
+    setData: PropTypes.func,
+    table: PropTypes.string.isRequired,
+    data: PropTypes.arrayOf(
+      PropTypes.shape({
+        id: PropTypes.string, 
+      }),
+    ),
+  };
+  
+  PaginationFooter.defaultProps = {
+    data: [],
+    table: '',
+    setData: () => {},
+  };
+
+export default PaginationFooter;
+
+
+

--- a/src/pages/Catalog/Catalog.jsx
+++ b/src/pages/Catalog/Catalog.jsx
@@ -1,18 +1,19 @@
 import { Table, Thead, Tbody, Tr, Th, Td, TableContainer } from '@chakra-ui/react';
-import { useState, useEffect } from 'react';
-import { NPOBackend } from '../../utils/auth_utils';
+import { useState } from 'react';
+// import { NPOBackend } from '../../utils/auth_utils';
+import PaginationFooter from '../../components/PaginationFooter/PaginationFooter';
 
 export default function Catalog() {
   const [tableData, setTableData] = useState([]);
 
-  useEffect(() => {
-    const fetchCatalogData = async () => {
-      const response = await NPOBackend.get('/catalog');
-      setTableData(response.data);
-    };
+  // useEffect(() => {
+  //   const fetchCatalogData = async () => {
+  //     const response = await NPOBackend.get('/catalog');
+  //     setTableData(response.data.events);
+  //   };
 
-    fetchCatalogData().catch(console.error);
-  }, []);
+  //   fetchCatalogData().catch(console.error);
+  // }, []);
 
   return (
     <TableContainer>
@@ -40,6 +41,7 @@ export default function Catalog() {
           ))}
         </Tbody>
       </Table>
+      <PaginationFooter table="catalog" setData={setTableData} />
     </TableContainer>
   );
 }

--- a/src/utils/auth_utils.js
+++ b/src/utils/auth_utils.js
@@ -182,7 +182,6 @@ const finishGoogleLoginRegistration = async (redirectPath, navigate) => {
  * @returns A boolean indicating whether or not the log in was successful
  */
 const logInWithEmailAndPassword = async (email, password, redirectPath, navigate, cookies) => {
-  console.log(auth.currentUser);
   await signInWithEmailAndPassword(auth, email, password);
   // Check if the user has verified their email.
   if (!auth.currentUser.emailVerified) {


### PR DESCRIPTION
- Created pagination footer component which can be reused for other tables
- Made catalog.js use pagination footer component
- Removed console.log in auth file because it was logging api key 💀

![image](https://github.com/ctc-uci/aiss-frontend/assets/40221474/a8f799d0-90a0-4649-96c8-1988acdf1524)

Some questions:
- The PNP example we referred to had a reusable pagination component which is why we also did that. Did we need to make it reusable? I'm not sure what possible future tables we may need (maybe managing users page?)
- How the pagination component works is that the Catalog page passes the component their setData, and then at the component level when the rows are clicked, it has a useEffect that uses the Catalog's setData. Is this fine? We were thinking it would be better practice to have it so that Catalog maintains control of all those states (total data count, row range, etc.) and then it's passed to pagination footer and lessening the components' functionality.

Closes #23 