### PR TITLE
81 final catalog adjustments frontend

### DIFF
--- a/src/components/Catalog/CatalogTable.jsx
+++ b/src/components/Catalog/CatalogTable.jsx
@@ -20,9 +20,9 @@ const CatalogTable = ({ tableData, handleActionClick, onDayPlanner, setCurrEvent
     >
       <Thead style={onDayPlanner ? { position: 'sticky', top: 0, backgroundColor: 'white', zIndex: 1 } : {}}>
         <Tr>
-          <Th width="20vw" textAlign="left">Event</Th>
-          <Th width="20vw" textAlign="left">Host</Th>
-          <Th width="20vw" textAlign="left">Tags</Th>
+          <Th width="19vw" maxWidth="19vw" textAlign="left">Event</Th>
+          <Th width="19vw" maxWidth="19vw" textAlign="left">Host</Th>
+          <Th width="19vw" maxWidth="19vw" textAlign="left">Tags</Th>
           <Th width="8rem"></Th>
         </Tr>
       </Thead>
@@ -30,13 +30,13 @@ const CatalogTable = ({ tableData, handleActionClick, onDayPlanner, setCurrEvent
         {tableData.map(({ id, host, title, eventType, subject, year, season, description}) => (
           <Tr key={id}>
             <Td textAlign="left" py="1.5rem" color="#2D3748">
-              <Text mb="0.5rem" fontWeight="700">{title}</Text>
-              <Text maxW="20vw" whiteSpace="pre-wrap">{description}</Text>
+              <Text width="19vw" maxW="19vw" mb="0.5rem" fontWeight="700" whiteSpace="pre-wrap" overflowWrap="break-word">{title}</Text>
+              <Text width="19vw" maxW="19vw" whiteSpace="pre-wrap" overflowWrap="break-word">{description}</Text>
             </Td>
-            <Td textAlign="left" py="1.5rem">
+            <Td width="19vw" textAlign="left" py="1.5rem" maxW="19vw" whiteSpace="pre-wrap" overflowWrap="break-word">
               {host}
             </Td>
-            <Td textAlign="left" py="1.5rem">
+            <Td width="19vw" maxW="19vw" textAlign="left" py="1.5rem">
               <Container p="0" m="0" maxW="16rem" display="flex" flexWrap="wrap" gap="0.375rem">
                 {season[0] !== '' && season.map((seasonItem, index) => (
                   <Badge

--- a/src/components/Catalog/CatalogTable.jsx
+++ b/src/components/Catalog/CatalogTable.jsx
@@ -20,9 +20,9 @@ const CatalogTable = ({ tableData, handleActionClick, onDayPlanner, setCurrEvent
     >
       <Thead style={onDayPlanner ? { position: 'sticky', top: 0, backgroundColor: 'white', zIndex: 1 } : {}}>
         <Tr>
-          <Th textAlign="left">Event</Th>
-          <Th textAlign="left">Host</Th>
-          <Th textAlign="left">Tags</Th>
+          <Th width="20vw" textAlign="left">Event</Th>
+          <Th width="20vw" textAlign="left">Host</Th>
+          <Th width="20vw" textAlign="left">Tags</Th>
           <Th width="8rem"></Th>
         </Tr>
       </Thead>


### PR DESCRIPTION
Locked width of each column to 19vw (20vw caused some odd bugs with host name overflowing into tags when given 50 char inputs with no spaces in them), wrapped text upon hitting boundary and pre-wrap on spaces.